### PR TITLE
Add JSX renderer middleware & render `WebsiteList`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A serverless website monitoring application built with the HONC stack (Hono, Ope
 
 ```#
 ├── src
-│   ├── index.ts # Hono app entry point
+│   ├── index.tsx # Hono app entry point
 │   └── db
 │       └── schema.ts # Database schema
 ├── .dev.vars.example # Example .dev.vars file

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "uptime-monitor",
   "scripts": {
-    "dev": "wrangler dev src/index.ts",
-    "deploy": "wrangler deploy --minify src/index.ts",
+    "dev": "wrangler dev src/index.tsx",
+    "deploy": "wrangler deploy --minify src/index.tsx",
     "db:touch": "wrangler d1 execute uptime-d1-database --local --command='SELECT 1'",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "wrangler d1 migrations apply uptime-d1-database --local",


### PR DESCRIPTION
Includes three fixes that make the `WebsiteList` go:
1. Rename `index.ts` to `index.tsx` as the file is handling JSX;
2. Include `jsxRenderer` to handle component rendering;
3. Include `<Style />` in the renderer's head tag so the CSS helper styles are injected.

---

![Screen Shot 2024-11-19 at 11 21 48](https://github.com/user-attachments/assets/e7dff7b8-6d46-48f1-a94c-eabadf37aba8)
